### PR TITLE
Server-side search & pagination, adjust react-query, and split UI components

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,93 @@
-import db from "../../../db";
-import { advocates } from "../../../db/schema";
-import { advocateData } from "../../../db/seed/advocates";
+import db from '../../../db';
+import { advocates as advocatesTable } from '../../../db/schema';
+import { advocateData } from '../../../db/seed/advocates';
 
-export async function GET() {
-  // Uncomment this line to use a database
-  // const data = await db.select().from(advocates);
+type SortField =
+  | 'firstName'
+  | 'lastName'
+  | 'city'
+  | 'degree'
+  | 'yearsOfExperience'
+  | 'phoneNumber';
 
-  const data = advocateData;
+const ALLOWED_SORT_FIELDS: SortField[] = [
+  'lastName',
+  'firstName',
+  'city',
+  'degree',
+  'yearsOfExperience',
+  'phoneNumber',
+];
 
-  return Response.json({ data });
+export async function GET(request: Request) {
+  // Uncomment this block when switching to database
+  // const allData = await db.select().from(advocatesTable);
+
+  const url = new URL(request.url);
+  const params = url.searchParams;
+
+  const q = (params.get('q') ?? '').trim().toLowerCase();
+  const pageRaw = params.get('page') ?? '1';
+  const pageSizeRaw = params.get('pageSize') ?? '20';
+  const sortRaw = (params.get('sort') as SortField | null) ?? 'lastName';
+  const orderRaw = (params.get('order') ?? 'asc').toLowerCase();
+
+  const page = Number(pageRaw);
+  const pageSize = Number(pageSizeRaw);
+  const sort: SortField = ALLOWED_SORT_FIELDS.includes(sortRaw)
+    ? sortRaw
+    : 'lastName';
+  const order: 'asc' | 'desc' = orderRaw === 'desc' ? 'desc' : 'asc';
+
+  if (!Number.isFinite(page) || page < 1) {
+    return new Response(JSON.stringify({ error: 'Invalid page' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+  if (!Number.isFinite(pageSize) || pageSize < 1 || pageSize > 100) {
+    return new Response(JSON.stringify({ error: 'Invalid pageSize' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  const source = advocateData; // replace with allData when DB enabled
+
+  const filtered = !q
+    ? source
+    : source.filter((adv) => {
+        const first = adv.firstName.toLowerCase();
+        const last = adv.lastName.toLowerCase();
+        const city = adv.city.toLowerCase();
+        const degree = adv.degree.toLowerCase();
+        const specialtiesJoined = adv.specialties.join(' ').toLowerCase();
+        const years = String(adv.yearsOfExperience);
+        const phone = String(adv.phoneNumber);
+        return (
+          first.includes(q) ||
+          last.includes(q) ||
+          city.includes(q) ||
+          degree.includes(q) ||
+          specialtiesJoined.includes(q) ||
+          years.includes(q) ||
+          phone.includes(q)
+        );
+      });
+
+  const sorted = filtered.slice().sort((a, b) => {
+    const dir = order === 'asc' ? 1 : -1;
+    const av = a[sort];
+    const bv = b[sort];
+    if (typeof av === 'number' && typeof bv === 'number') {
+      return (av - bv) * dir;
+    }
+    return String(av).localeCompare(String(bv)) * dir;
+  });
+
+  const total = sorted.length;
+  const start = (page - 1) * pageSize;
+  const data = sorted.slice(start, start + pageSize);
+
+  return Response.json({ data, total, page, pageSize, sort, order });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,144 +1,84 @@
 'use client';
 
 import { useState } from 'react';
-import type { Advocate } from '@/lib/types';
 import { useAdvocatesQuery } from '@/hooks/useAdvocatesQuery';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import AdvocatesTable from '@/components/advocates-table';
+import TableSkeleton from '@/components/table-skeleton';
+import SearchBar from '@/components/search-bar';
 
 export default function Home() {
   const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
 
-  const { data, isLoading, error } = useAdvocatesQuery();
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const { data, isLoading, error } = useAdvocatesQuery({
+    q: debouncedQuery,
+    page,
+    pageSize,
+    sort: 'lastName',
+    order: 'asc',
+  });
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const searchTerm = e.target.value;
-    setQuery(searchTerm);
-    const normalized = searchTerm.trim().toLowerCase();
-    const source: Advocate[] = data?.data ?? [];
-    if (!normalized) {
-      return;
-    }
-    const next = source.filter((advocate) => {
-      const first = advocate.firstName.toLowerCase();
-      const last = advocate.lastName.toLowerCase();
-      const city = advocate.city.toLowerCase();
-      const degree = advocate.degree.toLowerCase();
-      const specialtiesJoined = advocate.specialties.join(' ').toLowerCase();
-      const years = String(advocate.yearsOfExperience);
-      const phone = String(advocate.phoneNumber);
-      return (
-        first.includes(normalized) ||
-        last.includes(normalized) ||
-        city.includes(normalized) ||
-        degree.includes(normalized) ||
-        specialtiesJoined.includes(normalized) ||
-        years.includes(normalized) ||
-        phone.includes(normalized)
-      );
-    });
-    // no-op: filtering will be derived below; this handler only updates query
+    setQuery(e.target.value);
+    setPage(1);
   };
 
-  const onClick = () => {
+  const onReset = () => {
     setQuery('');
+    setPage(1);
   };
 
-  const advocates: Advocate[] = data?.data ?? [];
-  const normalized = query.trim().toLowerCase();
-  const filteredAdvocates: Advocate[] = !normalized
-    ? advocates
-    : advocates.filter((advocate) => {
-        const first = advocate.firstName.toLowerCase();
-        const last = advocate.lastName.toLowerCase();
-        const city = advocate.city.toLowerCase();
-        const degree = advocate.degree.toLowerCase();
-        const specialtiesJoined = advocate.specialties.join(' ').toLowerCase();
-        const years = String(advocate.yearsOfExperience);
-        const phone = String(advocate.phoneNumber);
-        return (
-          first.includes(normalized) ||
-          last.includes(normalized) ||
-          city.includes(normalized) ||
-          degree.includes(normalized) ||
-          specialtiesJoined.includes(normalized) ||
-          years.includes(normalized) ||
-          phone.includes(normalized)
-        );
-      });
+  const total = data?.total ?? 0;
+  const advocates = data?.data ?? [];
+  const maxPage = Math.max(1, Math.ceil(total / pageSize));
+  const startIndex = (page - 1) * pageSize + (advocates.length > 0 ? 1 : 0);
+  const endIndex = (page - 1) * pageSize + advocates.length;
 
   return (
     <main className='m-6'>
       <h1 className='text-2xl font-semibold'>Solace Advocates</h1>
-      <div className='mt-6 space-y-2'>
-        <label htmlFor='search' className='block text-sm font-medium'>
-          Search
-        </label>
-        <p aria-live='polite' className='text-sm text-gray-600'>
-          Searching for: <span>{query}</span>
-        </p>
-        <div className='flex items-center gap-2'>
-          <input
-            id='search'
-            value={query}
-            onChange={onChange}
-            className='border border-gray-300 rounded px-2 py-1 w-64'
-          />
-          <button
-            type='button'
-            onClick={onClick}
-            className='border rounded px-3 py-1 text-sm'
-          >
-            Reset Search
-          </button>
-        </div>
-      </div>
+      <SearchBar query={query} onChange={onChange} onReset={onReset} />
 
-      {isLoading && <p className='mt-6 text-gray-600'>Loading advocates…</p>}
+      {isLoading && <TableSkeleton rows={10} />}
       {error && !isLoading && (
         <p className='mt-6 text-red-600'>{error.message}</p>
       )}
-      {!isLoading && !error && filteredAdvocates.length === 0 && (
+      {!isLoading && !error && advocates.length === 0 && (
         <p className='mt-6 text-gray-600'>No results found.</p>
       )}
 
-      {!isLoading && !error && filteredAdvocates.length > 0 && (
+      {!isLoading && !error && advocates.length > 0 && (
         <div className='mt-6 overflow-x-auto'>
-          <table className='min-w-full border-collapse'>
-            <thead className='bg-gray-50'>
-              <tr>
-                <th className='text-left px-3 py-2 border'>First Name</th>
-                <th className='text-left px-3 py-2 border'>Last Name</th>
-                <th className='text-left px-3 py-2 border'>City</th>
-                <th className='text-left px-3 py-2 border'>Degree</th>
-                <th className='text-left px-3 py-2 border'>Specialties</th>
-                <th className='text-left px-3 py-2 border'>
-                  Years of Experience
-                </th>
-                <th className='text-left px-3 py-2 border'>Phone Number</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filteredAdvocates.map((advocate) => {
-                const rowKey = `${advocate.firstName}-${advocate.lastName}-${advocate.phoneNumber}`;
-                return (
-                  <tr key={rowKey} className='odd:bg-white even:bg-gray-50'>
-                    <td className='px-3 py-2 border'>{advocate.firstName}</td>
-                    <td className='px-3 py-2 border'>{advocate.lastName}</td>
-                    <td className='px-3 py-2 border'>{advocate.city}</td>
-                    <td className='px-3 py-2 border'>{advocate.degree}</td>
-                    <td className='px-3 py-2 border'>
-                      {advocate.specialties.map((s) => (
-                        <div key={s}>{s}</div>
-                      ))}
-                    </td>
-                    <td className='px-3 py-2 border'>
-                      {advocate.yearsOfExperience}
-                    </td>
-                    <td className='px-3 py-2 border'>{advocate.phoneNumber}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
+          <div className='mb-2 flex items-center justify-between'>
+            <div className='text-sm text-gray-700'>
+              {startIndex}-{endIndex} of {total}
+            </div>
+            <div className='flex items-center gap-2'>
+              <button
+                type='button'
+                className='border rounded px-3 py-1 text-sm disabled:opacity-50'
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1 || isLoading}
+              >
+                Prev
+              </button>
+              <span className='text-sm text-gray-700'>
+                Page {page} of {maxPage}
+              </span>
+              <button
+                type='button'
+                className='border rounded px-3 py-1 text-sm disabled:opacity-50'
+                onClick={() => setPage((p) => Math.min(maxPage, p + 1))}
+                disabled={page >= maxPage || isLoading}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+          <AdvocatesTable advocates={advocates} />
         </div>
       )}
     </main>

--- a/src/components/advocates-table.tsx
+++ b/src/components/advocates-table.tsx
@@ -1,0 +1,43 @@
+import type { Advocate } from '@/lib/types';
+
+export default function AdvocatesTable({
+  advocates,
+}: {
+  advocates: Advocate[];
+}) {
+  return (
+    <table className='min-w-full border-collapse'>
+      <thead className='bg-gray-50'>
+        <tr>
+          <th className='text-left px-3 py-2 border'>First Name</th>
+          <th className='text-left px-3 py-2 border'>Last Name</th>
+          <th className='text-left px-3 py-2 border'>City</th>
+          <th className='text-left px-3 py-2 border'>Degree</th>
+          <th className='text-left px-3 py-2 border'>Specialties</th>
+          <th className='text-left px-3 py-2 border'>Years of Experience</th>
+          <th className='text-left px-3 py-2 border'>Phone Number</th>
+        </tr>
+      </thead>
+      <tbody>
+        {advocates.map((advocate) => {
+          const rowKey = `${advocate.firstName}-${advocate.lastName}-${advocate.phoneNumber}`;
+          return (
+            <tr key={rowKey} className='odd:bg-white even:bg-gray-50'>
+              <td className='px-3 py-2 border'>{advocate.firstName}</td>
+              <td className='px-3 py-2 border'>{advocate.lastName}</td>
+              <td className='px-3 py-2 border'>{advocate.city}</td>
+              <td className='px-3 py-2 border'>{advocate.degree}</td>
+              <td className='px-3 py-2 border'>
+                {advocate.specialties.map((s) => (
+                  <div key={s}>{s}</div>
+                ))}
+              </td>
+              <td className='px-3 py-2 border'>{advocate.yearsOfExperience}</td>
+              <td className='px-3 py-2 border'>{advocate.phoneNumber}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+}

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -1,0 +1,33 @@
+type Props = {
+  query: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onReset: () => void;
+};
+
+export default function SearchBar({ query, onChange, onReset }: Props) {
+  return (
+    <div className='mt-6 space-y-2'>
+      <label htmlFor='search' className='block text-sm font-medium'>
+        Search
+      </label>
+      <p aria-live='polite' className='text-sm text-gray-600'>
+        Searching for: <span>{query}</span>
+      </p>
+      <div className='flex items-center gap-2'>
+        <input
+          id='search'
+          value={query}
+          onChange={onChange}
+          className='border border-gray-300 rounded px-2 py-1 w-64'
+        />
+        <button
+          type='button'
+          onClick={onReset}
+          className='border rounded px-3 py-1 text-sm'
+        >
+          Reset Search
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/table-skeleton.tsx
+++ b/src/components/table-skeleton.tsx
@@ -1,0 +1,28 @@
+export default function TableSkeleton({ rows = 10 }: { rows?: number }) {
+  return (
+    <div className='mt-6 overflow-x-auto animate-pulse'>
+      <table className='min-w-full border-collapse'>
+        <thead className='bg-gray-50'>
+          <tr>
+            {[...Array(7)].map((_, i) => (
+              <th key={i} className='text-left px-3 py-2 border'>
+                <div className='h-4 w-24 bg-gray-200 rounded' />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {[...Array(rows)].map((_, r) => (
+            <tr key={r} className='odd:bg-white even:bg-gray-50'>
+              {[...Array(7)].map((__, c) => (
+                <td key={c} className='px-3 py-2 border'>
+                  <div className='h-4 w-full bg-gray-200 rounded' />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/hooks/useAdvocatesQuery.ts
+++ b/src/hooks/useAdvocatesQuery.ts
@@ -1,16 +1,38 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import type { Advocate } from '@/lib/types';
 
-type AdvocatesResponse = { data: Advocate[] };
+export type AdvocatesResponse = {
+  data: Advocate[];
+  total: number;
+  page: number;
+  pageSize: number;
+  sort?: string;
+  order?: 'asc' | 'desc';
+};
 
-export function useAdvocatesQuery() {
+export function useAdvocatesQuery(params?: {
+  q?: string;
+  page?: number;
+  pageSize?: number;
+  sort?: string;
+  order?: 'asc' | 'desc';
+}) {
+  const searchParams = new URLSearchParams();
+  if (params?.q) searchParams.set('q', params.q);
+  if (params?.page) searchParams.set('page', String(params.page));
+  if (params?.pageSize) searchParams.set('pageSize', String(params.pageSize));
+  if (params?.sort) searchParams.set('sort', params.sort);
+  if (params?.order) searchParams.set('order', params.order);
+  const qs = searchParams.toString();
+
   return useQuery<AdvocatesResponse, Error>({
-    queryKey: ['advocates'],
+    queryKey: ['advocates', params],
     queryFn: async () => {
-      const response = await fetch('/api/advocates');
+      const response = await fetch(`/api/advocates${qs ? `?${qs}` : ''}`);
       if (!response.ok) throw new Error(`Failed to load: ${response.status}`);
       return response.json();
     },
-    staleTime: 60_000,
+    placeholderData: keepPreviousData,
+    staleTime: 30_000,
   });
 }

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,12 @@
+import { useEffect, useState } from 'react';
+
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebouncedValue(value), delayMs);
+    return () => clearTimeout(handle);
+  }, [value, delayMs]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
### Description
- Add API search/pagination: `GET /api/advocates` now supports `q`, `page`, `pageSize`, `sort`, `order` and returns `{ data, total, page, pageSize, sort, order }`.
- Integrate React Query with provider and `useAdvocatesQuery` hook; add debounced search.
- Convert page to client with server-driven filtering/pagination; remove client-side filtering.
- Extract components
- Type safety: `Advocate` in `src/lib/types.ts`.

### How to test (server search)
- Browser quick checks:
  - No filter: `http://localhost:3000/api/advocates`
  - Search: `http://localhost:3000/api/advocates?q=john`
  - Pagination: `http://localhost:3000/api/advocates?page=2&pageSize=5`
  - Sort: `http://localhost:3000/api/advocates?sort=firstName&order=desc`
  - 
- curl sanity:
```bash
curl -s 'http://localhost:3000/api/advocates' | jq '.total, .data[0]'
curl -s 'http://localhost:3000/api/advocates?q=md&sort=lastName&order=asc' | jq '.total'
curl -s 'http://localhost:3000/api/advocates?page=1&pageSize=5' | jq '.data | length'
curl -i 'http://localhost:3000/api/advocates?page=0' | head -n 1     # expect 400
curl -i 'http://localhost:3000/api/advocates?pageSize=1000' | head -n 1  # expect 400
```