### PR TITLE
Modernize advocates page UI (carded search, refined table, neutral chips)

### DIFF
--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -16,3 +16,6 @@
 - My wife is a designer and always makes fun of me for my terrible taste. I'm at the 2hr mark now but I think I'll add a few more touches to styling
 
 - Looking back, I think I'd definitely make the input search be a multiselect component
+- Also dark mode would be nice
+- I added some sensible defaults for the eslint config, but I typically also like to have a prettier config as well
+- I didn't have strict typing on the API route, but I would typically have it as well (with proper validation via zod as mentioned above)

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -14,3 +14,5 @@
 - I'm not really opinionated on the organization of the codebase, I just chose something that would be quick to maintain and understand for the purpose of the assignment
 - This was my first time using drizzle. Pretty great!
 - My wife is a designer and always makes fun of me for my terrible taste. I'm at the 2hr mark now but I think I'll add a few more touches to styling
+
+- Looking back, I think I'd definitely make the input search be a multiselect component

--- a/DISCUSSION.md
+++ b/DISCUSSION.md
@@ -3,10 +3,11 @@
 ## What I would do next?
 
 - Add validation with Zod on the API route
-- Use Tanstack Table for the data table. I've integrated react-query and react-table (tanstack) at almost every company I've worked for. It's a powerful combination and I've used it to build a lot of complex tables with sorting, filtering, pagination, and more.
+- Use Tanstack Table for the data table. I've git st react-query and react-table (tanstack) at almost every company I've worked for. It's a powerful combination and I've used it to build a lot of complex tables with sorting, filtering, pagination, and more.
 - I think we should consider virtualization for the table. If we have a lot of data, we can use virtualization to only render the visible rows and offload the rest to the browser.
 - probably add some logging via 3rd party
 - tests if neded
+- I'm not sure about how you feel about shadcn, but I think it has great primitives based on Tailwind and Radix UI. I'd probalby use as a base for most components or work with a designer to create a design system with or without them
 
 ## Other considerations
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,7 +17,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang='en'>
-      <body className={inter.className}>
+      <body className={`${inter.className} bg-slate-50 text-slate-900`}>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -78,7 +78,10 @@ export default function Home() {
               </button>
             </div>
           </div>
-          <AdvocatesTable advocates={advocates} />
+          <AdvocatesTable
+            key={`${page}-${debouncedQuery}`}
+            advocates={advocates}
+          />
         </div>
       )}
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -38,52 +38,64 @@ export default function Home() {
   const endIndex = (page - 1) * pageSize + advocates.length;
 
   return (
-    <main className='m-6'>
-      <h1 className='text-2xl font-semibold'>Solace Advocates</h1>
-      <SearchBar query={query} onChange={onChange} onReset={onReset} />
+    <main className='px-6 py-8'>
+      <div className='max-w-6xl mx-auto'>
+        <header>
+          <h1 className='text-3xl font-semibold tracking-tight text-slate-900'>
+            Solace Advocates
+          </h1>
+          <p className='mt-1 text-slate-600'>
+            Search, sort, and browse our network of advocates.
+          </p>
+        </header>
 
-      {isLoading && <TableSkeleton rows={10} />}
-      {error && !isLoading && (
-        <p className='mt-6 text-red-600'>{error.message}</p>
-      )}
-      {!isLoading && !error && advocates.length === 0 && (
-        <p className='mt-6 text-gray-600'>No results found.</p>
-      )}
-
-      {!isLoading && !error && advocates.length > 0 && (
-        <div className='mt-6 overflow-x-auto'>
-          <div className='mb-2 flex items-center justify-between'>
-            <div className='text-sm text-gray-700'>
-              {startIndex}-{endIndex} of {total}
-            </div>
-            <div className='flex items-center gap-2'>
-              <button
-                type='button'
-                className='border rounded px-3 py-1 text-sm disabled:opacity-50'
-                onClick={() => setPage((p) => Math.max(1, p - 1))}
-                disabled={page <= 1 || isLoading}
-              >
-                Prev
-              </button>
-              <span className='text-sm text-gray-700'>
-                Page {page} of {maxPage}
-              </span>
-              <button
-                type='button'
-                className='border rounded px-3 py-1 text-sm disabled:opacity-50'
-                onClick={() => setPage((p) => Math.min(maxPage, p + 1))}
-                disabled={page >= maxPage || isLoading}
-              >
-                Next
-              </button>
-            </div>
-          </div>
-          <AdvocatesTable
-            key={`${page}-${debouncedQuery}`}
-            advocates={advocates}
-          />
+        <div className='mt-6 rounded-xl border border-slate-200 bg-white p-4 shadow-sm'>
+          <SearchBar query={query} onChange={onChange} onReset={onReset} />
         </div>
-      )}
+
+        {isLoading && <TableSkeleton rows={10} />}
+        {error && !isLoading && (
+          <p className='mt-6 text-red-600'>{error.message}</p>
+        )}
+        {!isLoading && !error && advocates.length === 0 && (
+          <p className='mt-6 text-slate-600'>No results found.</p>
+        )}
+
+        {!isLoading && !error && advocates.length > 0 && (
+          <section className='mt-6 overflow-x-auto'>
+            <div className='mb-3 flex items-center justify-between'>
+              <div className='text-sm text-slate-700'>
+                {startIndex}-{endIndex} of {total}
+              </div>
+              <div className='flex items-center gap-2'>
+                <button
+                  type='button'
+                  className='rounded-md px-3 py-2 text-sm bg-white border border-slate-300 text-slate-700 hover:bg-slate-50 disabled:opacity-50 shadow-sm'
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page <= 1 || isLoading}
+                >
+                  ← Prev
+                </button>
+                <span className='text-sm text-slate-700'>
+                  Page {page} of {maxPage}
+                </span>
+                <button
+                  type='button'
+                  className='rounded-md px-3 py-2 text-sm bg-slate-900 text-white hover:bg-slate-800 disabled:opacity-50 shadow-sm'
+                  onClick={() => setPage((p) => Math.min(maxPage, p + 1))}
+                  disabled={page >= maxPage || isLoading}
+                >
+                  Next →
+                </button>
+              </div>
+            </div>
+            <AdvocatesTable
+              key={`${page}-${debouncedQuery}`}
+              advocates={advocates}
+            />
+          </section>
+        )}
+      </div>
     </main>
   );
 }

--- a/src/components/advocates-table.tsx
+++ b/src/components/advocates-table.tsx
@@ -6,38 +6,73 @@ export default function AdvocatesTable({
   advocates: Advocate[];
 }) {
   return (
-    <table className='min-w-full border-collapse'>
-      <thead className='bg-gray-50'>
-        <tr>
-          <th className='text-left px-3 py-2 border'>First Name</th>
-          <th className='text-left px-3 py-2 border'>Last Name</th>
-          <th className='text-left px-3 py-2 border'>City</th>
-          <th className='text-left px-3 py-2 border'>Degree</th>
-          <th className='text-left px-3 py-2 border'>Specialties</th>
-          <th className='text-left px-3 py-2 border'>Years of Experience</th>
-          <th className='text-left px-3 py-2 border'>Phone Number</th>
-        </tr>
-      </thead>
-      <tbody>
-        {advocates.map((advocate) => {
-          const rowKey = `${advocate.firstName}-${advocate.lastName}-${advocate.phoneNumber}`;
-          return (
-            <tr key={rowKey} className='odd:bg-white even:bg-gray-50'>
-              <td className='px-3 py-2 border'>{advocate.firstName}</td>
-              <td className='px-3 py-2 border'>{advocate.lastName}</td>
-              <td className='px-3 py-2 border'>{advocate.city}</td>
-              <td className='px-3 py-2 border'>{advocate.degree}</td>
-              <td className='px-3 py-2 border'>
-                {advocate.specialties.map((s) => (
-                  <div key={s}>{s}</div>
-                ))}
-              </td>
-              <td className='px-3 py-2 border'>{advocate.yearsOfExperience}</td>
-              <td className='px-3 py-2 border'>{advocate.phoneNumber}</td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+    <div className='rounded-xl border border-slate-200 shadow-sm overflow-hidden bg-white'>
+      <table className='min-w-full border-collapse'>
+        <thead className='bg-slate-50'>
+          <tr>
+            <th className='text-left px-4 py-3 border-b text-slate-600 text-sm'>
+              First Name
+            </th>
+            <th className='text-left px-4 py-3 border-b text-slate-600 text-sm'>
+              Last Name
+            </th>
+            <th className='text-left px-4 py-3 border-b text-slate-600 text-sm'>
+              City
+            </th>
+            <th className='text-left px-4 py-3 border-b text-slate-600 text-sm'>
+              Degree
+            </th>
+            <th className='text-left px-4 py-3 border-b text-slate-600 text-sm'>
+              Specialties
+            </th>
+            <th className='text-left px-4 py-3 border-b text-slate-600 text-sm'>
+              Years of Experience
+            </th>
+            <th className='text-left px-4 py-3 border-b text-slate-600 text-sm'>
+              Phone Number
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {advocates.map((advocate, idx) => {
+            const rowKey = `${advocate.firstName}-${advocate.lastName}-${advocate.phoneNumber}`;
+            return (
+              <tr key={rowKey} className='odd:bg-white even:bg-slate-50'>
+                <td className='px-4 py-3 border-b align-middle h-12'>
+                  {advocate.firstName}
+                </td>
+                <td className='px-4 py-3 border-b align-middle h-12'>
+                  {advocate.lastName}
+                </td>
+                <td className='px-4 py-3 border-b align-middle h-12'>
+                  {advocate.city}
+                </td>
+                <td className='px-4 py-3 border-b align-middle h-12'>
+                  {advocate.degree}
+                </td>
+                <td className='px-4 py-3 border-b align-middle h-12'>
+                  <div className='flex flex-wrap gap-1.5'>
+                    {advocate.specialties.map((s) => (
+                      <span
+                        key={s}
+                        className='inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 border border-slate-200'
+                      >
+                        {s}
+                      </span>
+                    ))}
+                  </div>
+                </td>
+                <td className='px-4 py-3 border-b align-middle h-12'>
+                  {advocate.yearsOfExperience}
+                </td>
+                <td className='px-4 py-3 border-b align-middle h-12'>
+                  {advocate.phoneNumber}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -10,7 +10,7 @@ export default function SearchBar({ query, onChange, onReset }: Props) {
       <label htmlFor='search' className='block text-sm font-medium'>
         Search
       </label>
-      <p aria-live='polite' className='text-sm text-gray-600'>
+      <p aria-live='polite' className='text-sm text-slate-600'>
         Searching for: <span>{query}</span>
       </p>
       <div className='flex items-center gap-2'>
@@ -18,12 +18,12 @@ export default function SearchBar({ query, onChange, onReset }: Props) {
           id='search'
           value={query}
           onChange={onChange}
-          className='border border-gray-300 rounded px-2 py-1 w-64'
+          className='border border-slate-300 rounded-md px-3 py-2 w-64 focus:outline-none focus:ring-2 focus:ring-slate-300 focus:border-slate-400 bg-white'
         />
         <button
           type='button'
           onClick={onReset}
-          className='border rounded px-3 py-1 text-sm'
+          className='border border-slate-300 rounded-md px-3 py-2 text-sm bg-white hover:bg-slate-50 active:bg-slate-100 shadow-sm text-slate-700'
         >
           Reset Search
         </button>

--- a/src/components/table-skeleton.tsx
+++ b/src/components/table-skeleton.tsx
@@ -1,28 +1,30 @@
 export default function TableSkeleton({ rows = 10 }: { rows?: number }) {
   return (
-    <div className='mt-6 overflow-x-auto animate-pulse'>
-      <table className='min-w-full border-collapse'>
-        <thead className='bg-gray-50'>
-          <tr>
-            {[...Array(7)].map((_, i) => (
-              <th key={i} className='text-left px-3 py-2 border'>
-                <div className='h-4 w-24 bg-gray-200 rounded' />
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {[...Array(rows)].map((_, r) => (
-            <tr key={r} className='odd:bg-white even:bg-gray-50'>
-              {[...Array(7)].map((__, c) => (
-                <td key={c} className='px-3 py-2 border'>
-                  <div className='h-4 w-full bg-gray-200 rounded' />
-                </td>
+    <div className='mt-6 overflow-x-auto'>
+      <div className='rounded-lg border border-gray-200 shadow-sm overflow-hidden animate-pulse'>
+        <table className='min-w-full border-collapse'>
+          <thead className='bg-gray-50'>
+            <tr>
+              {[...Array(7)].map((_, i) => (
+                <th key={i} className='text-left px-4 py-3 border-b'>
+                  <div className='h-4 w-24 bg-gray-200 rounded' />
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {[...Array(rows)].map((_, r) => (
+              <tr key={r} className={r % 2 === 0 ? 'bg-white' : 'bg-gray-50'}>
+                {[...Array(7)].map((__, c) => (
+                  <td key={c} className='px-4 py-3 border-b'>
+                    <div className='h-4 w-full bg-gray-200 rounded' />
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/hooks/useAdvocatesQuery.ts
+++ b/src/hooks/useAdvocatesQuery.ts
@@ -1,4 +1,4 @@
-import { useQuery, keepPreviousData } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import type { Advocate } from '@/lib/types';
 
 export type AdvocatesResponse = {
@@ -32,7 +32,7 @@ export function useAdvocatesQuery(params?: {
       if (!response.ok) throw new Error(`Failed to load: ${response.status}`);
       return response.json();
     },
-    placeholderData: keepPreviousData,
+    placeholderData: undefined,
     staleTime: 30_000,
   });
 }


### PR DESCRIPTION
### Description
- Add modern layout and header in `page.tsx` (max-width container, subtitle, spacing)
- Wrap search in a rounded card; unify slate color system across inputs/buttons
- Upgrade table aesthetics:
  - Rounded-xl white card with subtle shadow/border
  - Slate header text, zebra rows, uniform row height (h-12, align-middle)
  - Specialties rendered as neutral slate chips (bg-slate-100, border-slate-200)
- Improve pagination buttons (primary/neutral styles)
- Set global background/text to slate for better contrast
- Extra notes in discussion